### PR TITLE
librarian-puppet barfs on dependencies that are specified without version numbers

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -4,5 +4,5 @@ dependency 'puppetlabs/apt'
 license 'MIT'
 summary 'A module to intall the Sensu monitoring framework'
 project_page 'https://github.com/sensu/sensu-puppet'
-dependency 'puppetlabs/stdlib'
+dependency 'puppetlabs/stdlib', '>= 0.0.1'
 


### PR DESCRIPTION
See https://github.com/rodjek/librarian-puppet/pull/94
